### PR TITLE
Refactor: github-card 템플릿의 스타일과 스크립트를 분리

### DIFF
--- a/_includes/github-card.html
+++ b/_includes/github-card.html
@@ -1,111 +1,24 @@
-<div class="github-card-compact" data-url="{{ include.url }}" style="margin: 1rem 0; max-width: 600px;">
-  <a href="{{ include.url }}" target="_blank" rel="noopener noreferrer" style="text-decoration: none !important; border: none !important; display: block;">
-    <div style="background: var(--card-bg); border: 1px solid var(--main-border-color); border-radius: 8px; padding: 12px 16px; box-shadow: var(--card-shadow); transition: background 0.2s ease;">
+<div class="github-card-compact" data-url="{{ include.url }}">
+  <a href="{{ include.url }}" target="_blank" rel="noopener noreferrer" class="gh-link">
+    <div class="gh-card">
       
-      <div style="display: flex; align-items: center; gap: 8px; font-size: 0.8rem; color: var(--text-muted-color); margin-bottom: 6px;">
-        <i class="fab fa-github" style="font-size: 1rem;"></i>
-        <span class="gh-repo" style="font-weight: 500; letter-spacing: 0.1px;">불러오는 중...</span>
+      <div class="gh-header">
+        <i class="fab fa-github"></i>
+        <span class="gh-repo">Loading...</span>
       </div>
 
-      <div style="display: flex; align-items: center; gap: 8px; margin-top: 2px;">
-        <div class="gh-status-icon" style="display: flex; align-items: center; justify-content: center; width: 16px; min-height: 1.4rem;">
-          <i class="fas fa-circle-notch fa-spin" style="color: var(--text-muted-color); font-size: 0.85rem;"></i>
+      <div class="gh-meta">
+        <div class="gh-status-icon">
+          <i class="fas fa-circle-notch fa-spin"></i>
         </div>
-        <div class="gh-title" style="font-size: 1rem; font-weight: 600; color: var(--heading-color); line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden;">
-          Loading...
-        </div>
+        <div class="gh-title">Loading...</div>
       </div>
 
-      <div class="gh-desc" style="font-size: 0.85rem; color: var(--text-muted-color); margin: 4px 0 0 24px; display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden; opacity: 0.8;">
+      <div class="gh-desc">
         Synchronize information from GitHub...
       </div>
     </div>
   </a>
 </div>
 
-<script>
-(function() {
-  const CONFIG = {
-    LIMIT: 90,
-    COLOR: {
-      OPEN: '#3fb950',
-      CLOSED: '#8957e5'
-    },
-    ICON: {
-      ISSUE_OPEN: 'fas fa-circle-dot',
-      ISSUE_CLOSED: 'fas fa-check-circle',
-      PR_OPEN: 'fas fa-code-pull-request',
-      PR_CLOSED: 'fas fa-code-merge'
-    }
-  };
-  
-  const cardUrl = "{{ include.url }}";
-  const container = document.querySelector(`[data-url="${cardUrl}"]`);
-  if (!container) return;
-
-  const parseUrl = (url) => {
-    const p = url.replace("https://github.com/", "").split('/');
-    return { owner: p[0], repo: p[1], num: p[p.length - 1] };
-  };
-
-  const sanitizeText = (text, limit) => {
-    if (!text) return '내용 요약이 없습니다.';
-    
-    const clean = text.replace(/!\[.*\]\(.*\)/g, '')
-                      .replace(/\[(.*)\]\(.*\)/g, '$1')
-                      .replace(/[#*`\r\n]/g, ' ')
-                      .trim();
-                      
-    if (clean.length > limit) {
-      return clean.substring(0, limit) + '...';
-    }
-    return clean;
-  };
-
-  const getStatusTheme = (data) => {
-    const isPR = !!data.pull_request;
-    const isClosed = data.state === 'closed';
-
-    if (isPR) {
-      if (isClosed) {
-        return { icon: CONFIG.ICON.PR_CLOSED, color: CONFIG.COLOR.CLOSED };
-      }
-      return { icon: CONFIG.ICON.PR_OPEN, color: CONFIG.COLOR.OPEN };
-    }
-
-    if (isClosed) {
-      return { icon: CONFIG.ICON.ISSUE_CLOSED, color: CONFIG.COLOR.CLOSED };
-    }
-    return { icon: CONFIG.ICON.ISSUE_OPEN, color: CONFIG.COLOR.OPEN };
-  };
-  
-  const renderStatus = (target, data) => {
-    const iconEl = target.querySelector('.gh-status-icon i');
-    
-    const theme = getStatusTheme(data);
-
-    iconEl.className = theme.icon;
-    iconEl.style.color = theme.color;
-  };
-
-  const info = parseUrl(cardUrl);
-  const apiUrl = `https://api.github.com/repos/${info.owner}/${info.repo}/issues/${info.num}`;
-
-  fetch(apiUrl)
-    .then(res => {
-      if (!res.ok) throw new Error('API limit or not found');
-      return res.json();
-    })
-    .then(data => {
-      container.querySelector('.gh-title').innerText = data.title;
-      container.querySelector('.gh-repo').innerText = `${info.owner}/${info.repo} #${data.number}`;
-      container.querySelector('.gh-desc').innerText = sanitizeText(data.body, 90);
-      renderStatus(container, data);
-    })
-    .catch(err => {
-      container.querySelector('.gh-title').innerText = "GitHub 링크를 확인할 수 없습니다.";
-      container.querySelector('.gh-status-icon i').className = "fas fa-exclamation-triangle";
-      container.querySelector('.gh-status-icon i').style.color = "#d2603a";
-    });
-})();
-</script>
+<script src="/assets/js/github-card.js" defer></script>

--- a/_sass/addon/_github-card.scss
+++ b/_sass/addon/_github-card.scss
@@ -1,0 +1,80 @@
+.github-card-compact {
+  margin: 1rem 0;
+  max-width: 600px;
+
+  .gh-link {
+    text-decoration: none !important;
+    border: none !important;
+    display: block;
+    color: inherit;
+  }
+
+  .gh-card {
+    background: var(--card-bg, #fff);
+    border: 1px solid var(--main-border-color, #e1e4e8);
+    border-radius: 8px;
+    padding: 12px 16px;
+    box-shadow: var(--card-shadow, 0 1px 3px rgba(0,0,0,0.12));
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: var(--card-bg-hover, #f6f8fa);
+    }
+  }
+
+  .gh-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.8rem;
+    color: var(--text-muted-color, #656d76);
+    margin-bottom: 6px;
+
+    .gh-repo {
+      font-weight: 500;
+      letter-spacing: 0.1px;
+    }
+  }
+
+  .gh-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 2px;
+  }
+
+  .gh-status-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    min-height: 1.4rem;
+
+    i {
+      color: var(--text-muted-color, #656d76);
+      font-size: 0.85rem;
+    }
+  }
+
+  .gh-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--heading-color, #24292f);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .gh-desc {
+    font-size: 0.85rem;
+    color: var(--text-muted-color, #656d76);
+    margin: 4px 0 0 24px;
+    opacity: 0.8;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,5 @@
+---
+---
+
+@import "main";
+@import "addon/github-card";

--- a/assets/js/github-card.js
+++ b/assets/js/github-card.js
@@ -1,9 +1,10 @@
-/* assets/js/github-card.js */
-
-document.addEventListener("DOMContentLoaded", function() {
-  const cards = document.querySelectorAll('.github-card-compact');
-
-  if (cards.length === 0) return;
+document.addEventListener("DOMContentLoaded", () => {
+  const cards = Array.from(document.querySelectorAll('.github-card-compact'))
+                     .filter(container => !container.dataset.loaded && container.dataset.url);
+  
+  if (cards.length === 0) {
+    return;
+  }
 
   const CONFIG = {
     LIMIT: 90,
@@ -19,58 +20,97 @@ document.addEventListener("DOMContentLoaded", function() {
     }
   };
 
+  const parseUrl = (url) => {
+    const p = url.replace("https://github.com/", "")
+                 .split('/')
+                 .filter(Boolean);
+
+    if (p.length < 3) {
+      return null;
+    }
+    return { 
+      owner: p[0], 
+      repo: p[1], 
+      num: p[p.length - 1] 
+    };
+  };
+
+  const sanitizeText = (text, limit) => {
+    if (!text) {
+      return '내용 요약이 없습니다.';
+    }
+
+    const clean = text.replace(/!\[.*\]\(.*\)/g, '')
+                      .replace(/\[(.*)\]\(.*\)/g, '$1')
+                      .replace(/[#*`\r\n]/g, ' ')
+                      .trim();
+    
+    if (clean.length > limit) {
+      return clean.substring(0, limit) + '...';
+    }
+    return clean;
+  };
+
+  const getStatusTheme = (data) => {
+    const isPR = !!data.pull_request;
+    const isClosed = data.state === 'closed';
+
+    if (isPR) {
+      if (isClosed) {
+        return {
+          icon: CONFIG.ICON.PR_CLOSED, 
+          color: CONFIG.COLOR.CLOSED
+        };
+      }
+      return {
+        icon: CONFIG.ICON.PR_OPEN, 
+        color: CONFIG.COLOR.OPEN
+      };
+    }
+
+    if (isClosed) {
+      return { 
+        icon: CONFIG.ICON.ISSUE_CLOSED,
+        color: CONFIG.COLOR.CLOSED 
+      };
+    }
+    return { 
+      icon: CONFIG.ICON.ISSUE_OPEN, 
+      color: CONFIG.COLOR.OPEN 
+    };
+  };
+
+  const renderStatus = (target, data) => {
+    const iconEl = target.querySelector('.gh-status-icon i');
+    const theme = getStatusTheme(data);
+    iconEl.className = theme.icon;
+    iconEl.style.color = theme.color;
+  };
+
+  const renderError = (container) => {
+    container.querySelector('.gh-title').innerText = "잘못된 GitHub 링크";
+    const iconEl = container.querySelector('.gh-status-icon i');
+    iconEl.className = "fas fa-exclamation-triangle";
+    iconEl.style.color = "#d2603a";
+  };
+
   cards.forEach(container => {
-    // 중복 실행 방지
-    if (container.dataset.loaded) return;
     container.dataset.loaded = "true";
-
+    
     const cardUrl = container.dataset.url;
-    if (!cardUrl) return;
-
-    const parseUrl = (url) => {
-      const p = url.replace("https://github.com/", "").split('/');
-      // 간단한 파싱: owner/repo/issues/num
-      return { owner: p[0], repo: p[1], num: p[p.length - 1] };
-    };
-
-    const sanitizeText = (text, limit) => {
-      if (!text) return '내용 요약이 없습니다.';
-      const clean = text.replace(/!\[.*\]\(.*\)/g, '')
-                        .replace(/\[(.*)\]\(.*\)/g, '$1')
-                        .replace(/[#*`\r\n]/g, ' ')
-                        .trim();
-      if (clean.length > limit) {
-        return clean.substring(0, limit) + '...';
-      }
-      return clean;
-    };
-
-    const getStatusTheme = (data) => {
-      const isPR = !!data.pull_request;
-      const isClosed = data.state === 'closed';
-
-      if (isPR) {
-        if (isClosed) return { icon: CONFIG.ICON.PR_CLOSED, color: CONFIG.COLOR.CLOSED };
-        return { icon: CONFIG.ICON.PR_OPEN, color: CONFIG.COLOR.OPEN };
-      }
-
-      if (isClosed) return { icon: CONFIG.ICON.ISSUE_CLOSED, color: CONFIG.COLOR.CLOSED };
-      return { icon: CONFIG.ICON.ISSUE_OPEN, color: CONFIG.COLOR.OPEN };
-    };
-
-    const renderStatus = (target, data) => {
-      const iconEl = target.querySelector('.gh-status-icon i');
-      const theme = getStatusTheme(data);
-      iconEl.className = theme.icon;
-      iconEl.style.color = theme.color;
-    };
 
     const info = parseUrl(cardUrl);
+    if (!info) {
+      return renderError(container);
+    }
+
     const apiUrl = `https://api.github.com/repos/${info.owner}/${info.repo}/issues/${info.num}`;
 
     fetch(apiUrl)
       .then(res => {
-        if (!res.ok) throw new Error('API limit or not found');
+        if (!res.ok) {
+          throw new Error(`GitHub API error: ${res.status}`);
+        }
         return res.json();
       })
       .then(data => {
@@ -80,6 +120,7 @@ document.addEventListener("DOMContentLoaded", function() {
         renderStatus(container, data);
       })
       .catch(err => {
+        console.error(`Failed to fetch GitHub card data for ${cardUrl}:`, err);
         container.querySelector('.gh-title').innerText = "GitHub 링크 확인 불가";
         const iconEl = container.querySelector('.gh-status-icon i');
         iconEl.className = "fas fa-exclamation-triangle";

--- a/assets/js/github-card.js
+++ b/assets/js/github-card.js
@@ -1,0 +1,89 @@
+/* assets/js/github-card.js */
+
+document.addEventListener("DOMContentLoaded", function() {
+  const cards = document.querySelectorAll('.github-card-compact');
+
+  if (cards.length === 0) return;
+
+  const CONFIG = {
+    LIMIT: 90,
+    COLOR: {
+      OPEN: '#3fb950',
+      CLOSED: '#8957e5'
+    },
+    ICON: {
+      ISSUE_OPEN: 'fas fa-circle-dot',
+      ISSUE_CLOSED: 'fas fa-check-circle',
+      PR_OPEN: 'fas fa-code-pull-request',
+      PR_CLOSED: 'fas fa-code-merge'
+    }
+  };
+
+  cards.forEach(container => {
+    // 중복 실행 방지
+    if (container.dataset.loaded) return;
+    container.dataset.loaded = "true";
+
+    const cardUrl = container.dataset.url;
+    if (!cardUrl) return;
+
+    const parseUrl = (url) => {
+      const p = url.replace("https://github.com/", "").split('/');
+      // 간단한 파싱: owner/repo/issues/num
+      return { owner: p[0], repo: p[1], num: p[p.length - 1] };
+    };
+
+    const sanitizeText = (text, limit) => {
+      if (!text) return '내용 요약이 없습니다.';
+      const clean = text.replace(/!\[.*\]\(.*\)/g, '')
+                        .replace(/\[(.*)\]\(.*\)/g, '$1')
+                        .replace(/[#*`\r\n]/g, ' ')
+                        .trim();
+      if (clean.length > limit) {
+        return clean.substring(0, limit) + '...';
+      }
+      return clean;
+    };
+
+    const getStatusTheme = (data) => {
+      const isPR = !!data.pull_request;
+      const isClosed = data.state === 'closed';
+
+      if (isPR) {
+        if (isClosed) return { icon: CONFIG.ICON.PR_CLOSED, color: CONFIG.COLOR.CLOSED };
+        return { icon: CONFIG.ICON.PR_OPEN, color: CONFIG.COLOR.OPEN };
+      }
+
+      if (isClosed) return { icon: CONFIG.ICON.ISSUE_CLOSED, color: CONFIG.COLOR.CLOSED };
+      return { icon: CONFIG.ICON.ISSUE_OPEN, color: CONFIG.COLOR.OPEN };
+    };
+
+    const renderStatus = (target, data) => {
+      const iconEl = target.querySelector('.gh-status-icon i');
+      const theme = getStatusTheme(data);
+      iconEl.className = theme.icon;
+      iconEl.style.color = theme.color;
+    };
+
+    const info = parseUrl(cardUrl);
+    const apiUrl = `https://api.github.com/repos/${info.owner}/${info.repo}/issues/${info.num}`;
+
+    fetch(apiUrl)
+      .then(res => {
+        if (!res.ok) throw new Error('API limit or not found');
+        return res.json();
+      })
+      .then(data => {
+        container.querySelector('.gh-title').innerText = data.title;
+        container.querySelector('.gh-repo').innerText = `${info.owner}/${info.repo} #${data.number}`;
+        container.querySelector('.gh-desc').innerText = sanitizeText(data.body, 90);
+        renderStatus(container, data);
+      })
+      .catch(err => {
+        container.querySelector('.gh-title').innerText = "GitHub 링크 확인 불가";
+        const iconEl = container.querySelector('.gh-status-icon i');
+        iconEl.className = "fas fa-exclamation-triangle";
+        iconEl.style.color = "#d2603a";
+      });
+  });
+});


### PR DESCRIPTION
## 개요 
기존에 `_includes/github-card.html` 파일 하나에 혼재되어 있던 HTML 구조, 인라인 스타일(CSS), 스크립트(JS) 로직을 각각의 역할에 맞는 파일로 분리하고 리팩토링을 진행함

## 기존 문제
1. **가독성 저하:** 과도한 인라인 스타일(`style="..."`) 사용으로 인해 HTML 구조 파악이 어려움
2. **유지보수 어려움:** 디자인을 수정하거나 로직을 변경할 때 한 파일 내에서 코드를 찾아야 해서 비효율적임
3. **확장성 부족:** Chirpy 테마의 SCSS 구조를 활용하지 못하고 하드코딩된 스타일을 사용함

## 변경 사항
관심사의 분리(Separation of Concerns) 원칙에 따라 파일을 다음과 같이 분리

 1. 스타일 분리 (SCSS)
  - 인라인 스타일을 제거하고 SCSS 클래스로 스타일을 정의
  - 테마의 기본 스타일(`main`)을 불러오고, 커스텀 스타일(`addon/github-card`)을 오버라이딩하도록 설정

2. 로직 분리 (JavaScript)
  - `fetch` API 호출 및 DOM 조작 로직을 별도 JS 파일로 추출
  - `data-url` 속성을 통해 비동기로 데이터를 로드하도록 구조 개선

3. 구조 단순화 (HTML)
  - 불필요한 스타일 코드를 제거하고 시맨틱한 마크업 구조만 남김

## ✅ 체크리스트 (Checklist)
- [x] 로컬 빌드(`bundle exec jekyll build`) 시 에러가 없는가?
- [x] GitHub Card가 포스트 내에서 정상적으로 렌더링 되는가?
- [x] 기존 기능(API 데이터 호출 등)이 정상 작동하는가?