### PR TITLE
Fix: linkpreview 배포 조건 변경

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -75,6 +75,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ end
 gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
 group :jekyll_plugins do
-  gem "jekyll-linkpreview"
+  gem "jekyll-linkpreview", :git => "https://github.com/Rigu1/jekyll-linkpreview.git", :branch => "master"
 end


### PR DESCRIPTION
## 개요
1. 기존 linkpreview 플러그인 구조상 빌드 테스트를 통과할 수 없어 이를 수정한 뒤 배포했고,  기존 linkpreview 플러그인이 아닌 배포된 레포를 참조하도록 수정
2. PR 빌드 테스트 후 배포가 진행되지 않도록 수정

## 기존 문제
1. jekyll로 빌드된 _site 폴더에서 linkpreview 플러그인이 적용된 포스트의 html파일에 스키마(http/https)가 없는 링크가 생성되어 Git Actions의 빌드를 깨드림
2. PR 빌드 테스트 후 배포가 진행됨

## 변경 사항
1. 기존 linkpreview 플러그인이 아닌 이미지 경로 문제를 해결한 레포를 참조하도록 수정
2. main 브랜치일 때만 배포가 진행되도록 변경함

## 관련 이슈
Closes #1 
Closes #3 