### PR TITLE
Fix: jekyll-sitemap 플러그인 추가

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
 group :jekyll_plugins do
   gem "jekyll-linkpreview", :git => "https://github.com/Rigu1/jekyll-linkpreview.git", :branch => "master"
+  gem "jekyll-sitemap"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@
 # plugins
 plugins:
   - jekyll-linkpreview
+  - jekyll-sitemap
 
 # Import the theme
 theme: jekyll-theme-chirpy


### PR DESCRIPTION
## 개요
jekyll-sitemap 플러그인을 추가하여 사이트맵 인식 문제 해결
## 기존 문제
google saerch console의 sitemap 크롤링 결과를 확인하니 sitemap.xml에 jekyll HTML 기본 레이아웃이 적용되어 google saerch console이 사이트맵을 인식하지 못함
PR 빌드 테스트 후 배포가 진행됨
## 변경 사항
 jekyll-sitemap 플러그인을 추가함

관련 이슈
Closes #7 